### PR TITLE
Changes in parametrized geometry, generation and output maps

### DIFF
--- a/interface/Cell.h
+++ b/interface/Cell.h
@@ -9,7 +9,7 @@ class Cell {
   // an polygonal cell
 
   public:
-    static uint32_t id(int16_t i, int16_t j);
+    static uint32_t id(uint16_t i, uint16_t j);
 
   private:
     Cell() {} // don't use default constructor

--- a/interface/Event.h
+++ b/interface/Event.h
@@ -14,15 +14,14 @@ class Event
     ~Event() {};
 
     void fillHit(uint32_t, double);
-    void setGenerated(double, double, double, double);
+    void setGenerated(double, double, double);
     void clear();
 
     const uint32_t run() const {return run_;}
     const uint32_t event() const {return event_;}
     const double generatedEnergy() const {return generated_energy_;}
-    const double generatedX() const {return generated_x_;}
-    const double generatedY() const {return generated_y_;}
     const double generatedEta() const {return generated_eta_;}
+    const double generatedPhi() const {return generated_phi_;}
     const std::unordered_map<uint32_t, double>& hits() const {return hits_;}
 
   private:
@@ -30,9 +29,8 @@ class Event
     uint32_t event_;
     // FIXME: improve generated information
     double generated_energy_;
-    double generated_x_;
-    double generated_y_;
     double generated_eta_;
+    double generated_phi_;
     std::unordered_map<uint32_t, double> hits_;
 
 

--- a/interface/Geometry.h
+++ b/interface/Geometry.h
@@ -79,10 +79,6 @@ class Geometry {
     double asqrt3over2_;
     const Parameters::Geometry& parameters_;
 
-    // FIXME
-    // This is supposed to be written into a root file
-    // So it is currently not owned by the geometry
-    // But maybe better to have a unique_ptr + SetDirectory(0)
     std::unique_ptr<TH2Poly> cell_histogram_;
 
 };

--- a/interface/Geometry.h
+++ b/interface/Geometry.h
@@ -58,7 +58,7 @@ class Geometry {
     double a3over2() const {return a3over2_;}
     double asqrt3over2() const {return asqrt3over2_;}
 
-    const TH2Poly* cellHistogram() const {return cell_histogram_;}
+    const std::unique_ptr<TH2Poly>& cellHistogram() const {return cell_histogram_;}
     void draw(const Parameters::Display& params);
     void print();
 
@@ -83,7 +83,7 @@ class Geometry {
     // This is supposed to be written into a root file
     // So it is currently not owned by the geometry
     // But maybe better to have a unique_ptr + SetDirectory(0)
-    TH2Poly* cell_histogram_;
+    std::unique_ptr<TH2Poly> cell_histogram_;
 
 };
 

--- a/interface/Geometry.h
+++ b/interface/Geometry.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include "TVectorD.h"
 #include "TMatrixD.h"
+#include "TH2Poly.h"
 #ifdef STANDALONE
 #include "Cell.h"
 #include "Parameters.h"
@@ -21,8 +22,6 @@ class Geometry {
   // a tesselation of the plane with polygonal cells
   // by default the plane is at z=0 but can be shifted to a z position that
   // corresponds to a layer position from TP geometry 
-  // itype=0: hexagonal cells
-  // itype=1: triangular cells
 
   public:
 
@@ -48,11 +47,7 @@ class Geometry {
     //vect<Cell> getSecondNeighbours (int i); // not yet implemented
 
     // getters
-    int getNumberOfRows() const {return nrows_;} // parameterized case
-    int getNumberOfCols() const {return ncols_;} // parameterized case
     const std::unordered_map<uint32_t, Cell>& getCells() const {return cells_;}
-    //int getIIndex(const Cell& cell) const;
-    //int getJIndex(const Cell& cell) const;
     int getLayer() const {return klayer_;}
     double getZlayer() const {return zlayer_;}
     Parameters::Geometry::Type getType() const {return itype_;} 
@@ -60,31 +55,35 @@ class Geometry {
     double a() const {return a_;}
     double asqrt3() const {return asqrt3_;}
     double aover2() const {return aover2_;}
+    double a3over2() const {return a3over2_;}
     double asqrt3over2() const {return asqrt3over2_;}
 
-    void draw(const Parameters::Display& params, double scale=0.1);
+    const TH2Poly* cellHistogram() const {return cell_histogram_;}
+    void draw(const Parameters::Display& params);
     void print();
 
   private:
 
-    //void setCells(std::vector<Cell *> cells) {cells_ = cells;}
-    void setNrows(int nrows) {nrows_ = nrows;}
-    void setNcols(int ncols) {ncols_ = ncols;}
     void setLayer(int klayer);
     void setZlayer(double zlayer) {zlayer_ = zlayer;}
     void setType (Parameters::Geometry::Type itype) {itype_=itype;}
 
     std::unordered_map<uint32_t, Cell> cells_;
-    int nrows_;
-    int ncols_;
     int klayer_;
     double zlayer_;
     Parameters::Geometry::Type itype_; // cell type
     double a_;
     double asqrt3_;
     double aover2_;
+    double a3over2_;
     double asqrt3over2_;
     const Parameters::Geometry& parameters_;
+
+    // FIXME
+    // This is supposed to be written into a root file
+    // So it is currently not owned by the geometry
+    // But maybe better to have a unique_ptr + SetDirectory(0)
+    TH2Poly* cell_histogram_;
 
 };
 

--- a/interface/OutputService.h
+++ b/interface/OutputService.h
@@ -33,8 +33,7 @@ class OutputService
     unsigned event_;
     float gen_energy_;
     float gen_eta_;
-    float gen_x_;
-    float gen_y_;
+    float gen_phi_;
     unsigned cell_n_;
     std::vector<float> cell_energy_;
     std::vector<float> cell_x_;

--- a/interface/Parameters.h
+++ b/interface/Parameters.h
@@ -27,9 +27,10 @@ class Parameters
       std::vector<double> layers_z;
       // internal infinite geometries
       double cell_side;
-      int offset;
-      int cells_nx;
-      int cells_ny;
+      double eta_min;
+      double eta_max;
+      double phi_min;
+      double phi_max;
       // external geometries
       std::string file;
     };

--- a/interface/Parameters.h
+++ b/interface/Parameters.h
@@ -55,9 +55,8 @@ class Parameters
       double sampling;
       bool noise;
       double noise_sigma;
-      double incident_x;
-      double incident_y;
       double incident_eta;
+      double incident_phi;
     };
     struct Display
     {

--- a/interface/Parameters.h
+++ b/interface/Parameters.h
@@ -62,9 +62,6 @@ class Parameters
     {
       Display();
       unsigned events;
-      int size;
-      double offset_x;
-      double offset_y;
     };
 
   public:

--- a/python/display_cfg.py
+++ b/python/display_cfg.py
@@ -1,5 +1,2 @@
 
 display_events = 5
-display_size = 15
-display_offset_x = 0.5
-display_offset_y = 0.5

--- a/python/generation_cfg.py
+++ b/python/generation_cfg.py
@@ -17,12 +17,8 @@ generation_noise = True
 # noise in mips
 generation_noise_sigma = 0.3
 
-# Incident position and angle
-# below we shoot at center of the (3,4) cell in the parameterised triangular geometry
-incident_i = 3
-incident_j = 4
-generation_incident_x = incident_i*a/2.+incident_j*a/2.
-generation_incident_y = incident_j*a*m.sqrt(3.)+(incident_i+1)%2*a*m.sqrt(3.)/6.
+# Incident direction
 generation_incident_eta = 2.
+generation_incident_phi = 0.
 
 

--- a/python/geometry_cfg.py
+++ b/python/geometry_cfg.py
@@ -1,7 +1,7 @@
 
 import math as m
 
-geometry_type = 'Triangles'
+geometry_type = 'Hexagons'
 # layer:
 # if between 0 and 27, the generated energy is weighted according to the layer profile (elayers[i])
 # the incident position is also shifted according to layer z position (zlayers[i]) and incident direction (etainc)

--- a/python/geometry_cfg.py
+++ b/python/geometry_cfg.py
@@ -1,7 +1,7 @@
 
 import math as m
 
-geometry_type = 'Hexagons'
+geometry_type = 'Triangles'
 # layer:
 # if between 0 and 27, the generated energy is weighted according to the layer profile (elayers[i])
 # the incident position is also shifted according to layer z position (zlayers[i]) and incident direction (etainc)
@@ -23,9 +23,9 @@ geometry_cells_ny = 31
 # offset <0 starting cell along x, this is to fully fill the display window
 geometry_offset = -9
 
-geometry_eta_min = 1.8
-geometry_eta_max = 2.5
-geometry_phi_min = -m.pi/12. # -15 deg 
-geometry_phi_max = m.pi/12. # +15 deg 
+geometry_eta_min = 1.9
+geometry_eta_max = 2.1
+geometry_phi_min = -m.pi/24. # -7.5 deg 
+geometry_phi_max = m.pi/24. # +7.5 deg 
 #
 geometry_file = 'data/AC_11.json'

--- a/python/geometry_cfg.py
+++ b/python/geometry_cfg.py
@@ -1,4 +1,6 @@
 
+import math as m
+
 geometry_type = 'Triangles'
 # layer:
 # if between 0 and 27, the generated energy is weighted according to the layer profile (elayers[i])
@@ -20,5 +22,10 @@ geometry_cells_nx = 31
 geometry_cells_ny = 31
 # offset <0 starting cell along x, this is to fully fill the display window
 geometry_offset = -9
+
+geometry_eta_min = 1.8
+geometry_eta_max = 2.5
+geometry_phi_min = -m.pi/12. # -15 deg 
+geometry_phi_max = m.pi/12. # +15 deg 
 #
 geometry_file = 'data/AC_11.json'

--- a/python/geometry_cfg.py
+++ b/python/geometry_cfg.py
@@ -8,21 +8,21 @@ geometry_type = 'Triangles'
 # if set to -1, the full generated energy is deposited without longitudinal weighting and the
 # incident position is not shifted, that is it corresponds to layer 0 with the full energy deposited in it
 geometry_layer = -1
-# layers' z positions, this should move in the geometry
+# layers' z positions
 # from CMSSW V7 geometry: https://indico.cern.ch/event/458374/contribution/9/attachments/1179028/1828217/Andreev_29Oct2015.pdf 
 # the values are the silicon (centre) z positions of the 28 layers wrt HGCAL z entry position in cm
 geometry_layers_z = [.765,1.515,2.745,3.495,4.725,5.475,6.705,7.455,8.685,9.435,
                        10.745,11.615,12.925,13.795,15.105,15.975,17.285,18.155,19.465,20.335,
                        21.785,22.855,24.305,25.375,26.825,27.895,29.345,30.415]
+# entry point in HGCal
+z0 = 320.
+# absolute HGCal layer positions
+geometry_layers_z[:] = [z+z0 for z in geometry_layers_z]
+
 # multiply cell side by sqrt(6) for triangles to get equal area
 geometry_cell_side = 1.190
-# number of cells along x
-geometry_cells_nx = 31
-# number of cells along y
-geometry_cells_ny = 31
-# offset <0 starting cell along x, this is to fully fill the display window
-geometry_offset = -9
 
+# Define (eta,phi) window to build the geometry
 geometry_eta_min = 1.9
 geometry_eta_max = 2.1
 geometry_phi_min = -m.pi/24. # -7.5 deg 

--- a/src/Cell.cpp
+++ b/src/Cell.cpp
@@ -8,7 +8,7 @@
 #endif
 
 
-uint32_t Cell::id(int16_t i, int16_t j)
+uint32_t Cell::id(uint16_t i, uint16_t j)
 {
   uint32_t id = 0;
   id |= i;

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -25,12 +25,11 @@ fillHit(uint32_t id, double energy)
 
 void
 Event::
-setGenerated(double energy, double x, double y, double eta)
+setGenerated(double energy, double eta, double phi)
 {
   generated_energy_ = energy;
-  generated_x_ = x;
-  generated_y_  = y;
   generated_eta_ = eta;
+  generated_phi_ = phi;
 }
 
 void

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -271,7 +271,7 @@ void Generator::simulate() {
         hCellEnergyEvtMap.at(id_energy.first).Reset();
         hCellEnergyEvtMap.at(id_energy.first).Fill(id_energy.second);
       }
-      //canvas.emplace_back(display(hCellEnergyEvtMap,iev));    
+      canvas.emplace_back(display(hCellEnergyEvtMap,iev));    
 
     }
     output_.fillTree(event, geometry_);

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -42,6 +42,7 @@ void Generator::simulate() {
   // incident direction
   // coordinate of origin of simulated geometry/module in CMS frame is given by etainc,phiinc and z=320.;
   // set phiinc to 0., can be updated when we will have seval modules
+  // FIXME: remove hardcoded phi and z0
   double phiinc = 0.;
   double thetainc = 2.*std::atan(std::exp(-parameters_.generation().incident_eta));
   double z0 = 320.; // z ccordinate of first plane
@@ -65,10 +66,7 @@ void Generator::simulate() {
   std::string title;
   title = "Layer ";
   title = title + std::to_string(parameters_.geometry().layer);
-  // FIXME: where is used this canvas?
-  TCanvas c1(title.c_str(),title.c_str(),40,40,700,700);
-  double scale=1.;
-  geometry_.draw(parameters_.display(), scale);
+
 
   ShowerParametrization aShowerParametrization(parameters_.shower());
 
@@ -118,9 +116,6 @@ void Generator::simulate() {
       parameters_.generation().incident_y<<")"<<std::endl; 
     std::cout << "incident energy: " <<parameters_.generation().energy<<" GeV"<<std::endl; 
     std::cout << "requested layer: " <<parameters_.geometry().layer<<std::endl; 
-    std::cout<< "cell grid: " <<"("<<
-      parameters_.geometry().cells_nx<<","<<
-      parameters_.geometry().cells_ny<<")"<< std::endl;
     std::cout<< "hexagon side: " <<parameters_.geometry().cell_side<< std::endl;
 
     std::cout<< "moliere radius: " << aShowerParametrization.getMoliereRadius()  << " cm" << std::endl;
@@ -283,7 +278,7 @@ void Generator::simulate() {
         hCellEnergyEvtMap.at(id_energy.first).Reset();
         hCellEnergyEvtMap.at(id_energy.first).Fill(id_energy.second);
       }
-      canvas.emplace_back(display(hCellEnergyEvtMap,iev));    
+      //canvas.emplace_back(display(hCellEnergyEvtMap,iev));    
 
     }
     output_.fillTree(event, geometry_);
@@ -295,16 +290,16 @@ void Generator::simulate() {
   std::cout << std::endl;
 
   // Exporting histograms to file
-  hEnergyGen.Write();
-  hTransverseProfile.Write();
-  hPhiProfile.Write();
-  hSpotEnergy.Write();
-  hCellEnergyDist.Write();
-  hEnergySum.Write();
+  //hEnergyGen.Write();
+  //hTransverseProfile.Write();
+  //hPhiProfile.Write();
+  //hSpotEnergy.Write();
+  //hCellEnergyDist.Write();
+  //hEnergySum.Write();
 
-  for (const auto& id_hist : hCellEnergyMap) { 
-    id_hist.second.Write();
-  }  
+  //for (const auto& id_hist : hCellEnergyMap) { 
+    //id_hist.second.Write();
+  //}  
 
 
   t.Stop();
@@ -361,12 +356,12 @@ std::unique_ptr<TCanvas> Generator::display(const std::unordered_map<uint32_t,TH
   title = title + ", ";
   title = title + title4;
 
-  std::unique_ptr<TCanvas> c1(new TCanvas(title.c_str(),title.c_str(),40,40,700,700));
+  std::unique_ptr<TCanvas> c1(new TCanvas(title.c_str(),title.c_str(),700,700));
   double scale=1./(parameters_.display().size*geometry_.asqrt3());
   if (parameters_.geometry().type==Parameters::Geometry::Type::Triangles) scale=1./(parameters_.display().size*geometry_.aover2());
   if (parameters_.geometry().type==Parameters::Geometry::Type::External) scale=1./(parameters_.display().size*0.22727*sqrt(3.)); // FIXME: hard coded a size for json geometry, to be improved
   //double textsize=0.02;
-  geometry_.draw(parameters_.display(), scale);
+  geometry_.draw(parameters_.display());
 
 
   for (const auto& id_hist : hCellEnergyEvtMap) {

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -51,17 +51,16 @@ void Generator::simulate() {
   }
   if(debug) geometry_.print();
 
+  // The output file has the ownership
+  TH2Poly* geometry_histo = (TH2Poly*)geometry_.cellHistogram()->Clone("geometry");
+  geometry_histo->Write();
+
   // incident direction
   double phiinc = parameters_.generation().incident_phi;
   double thetainc = 2.*std::atan(std::exp(-parameters_.generation().incident_eta));
   double r = geometry_.getZlayer()*tan(thetainc); 
   double incident_x = r*cos(phiinc);
   double incident_y = r*sin(phiinc);
-
-  // draw the geometry
-  std::string title;
-  title = "Layer ";
-  title = title + std::to_string(parameters_.geometry().layer);
 
 
   ShowerParametrization aShowerParametrization(parameters_.shower());

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -39,17 +39,7 @@ void Generator::simulate() {
   double energygenincells=0.;
   double energyrec=0.;
 
-  // incident direction
-  // coordinate of origin of simulated geometry/module in CMS frame is given by etainc,phiinc and z=320.;
-  // FIXME: remove hardcoded z0
-  double phiinc = parameters_.generation().incident_phi;
-  double thetainc = 2.*std::atan(std::exp(-parameters_.generation().incident_eta));
-  double z0 = 320.; // z ccordinate of first plane
-  double rt = z0*tan(thetainc); 
-  TVectorD direction(3);  
-  direction(0) = rt*cos(phiinc);
-  direction(1) = rt*sin(phiinc);
-  direction(2) = z0;
+
 
   TStopwatch t;
   t.Start();   
@@ -60,6 +50,13 @@ void Generator::simulate() {
     geometry_.constructFromJson(parameters_.general().debug);
   }
   if(debug) geometry_.print();
+
+  // incident direction
+  double phiinc = parameters_.generation().incident_phi;
+  double thetainc = 2.*std::atan(std::exp(-parameters_.generation().incident_eta));
+  double r = geometry_.getZlayer()*tan(thetainc); 
+  double incident_x = r*cos(phiinc);
+  double incident_y = r*sin(phiinc);
 
   // draw the geometry
   std::string title;
@@ -180,11 +177,6 @@ void Generator::simulate() {
         std::endl;
     }
 
-    // incident position
-    // FIXME: use absolute z position  in config
-    double z = geometry_.getZlayer() + z0;
-    double incident_x = z*direction(0)/direction(2);
-    double incident_y = z*direction(1)/direction(2);
 
     for (int i=0; i<nhits; i++) {
 

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -41,9 +41,8 @@ void Generator::simulate() {
 
   // incident direction
   // coordinate of origin of simulated geometry/module in CMS frame is given by etainc,phiinc and z=320.;
-  // set phiinc to 0., can be updated when we will have seval modules
-  // FIXME: remove hardcoded phi and z0
-  double phiinc = 0.;
+  // FIXME: remove hardcoded z0
+  double phiinc = parameters_.generation().incident_phi;
   double thetainc = 2.*std::atan(std::exp(-parameters_.generation().incident_eta));
   double z0 = 320.; // z ccordinate of first plane
   double rt = z0*tan(thetainc); 
@@ -111,9 +110,9 @@ void Generator::simulate() {
   if (debug)
   {
     std::cout << " " << std::endl;
-    std::cout << "incident position: " <<"("<<
-      parameters_.generation().incident_x<<","<<
-      parameters_.generation().incident_y<<")"<<std::endl; 
+    std::cout << "incident direction: " <<"("<<
+      parameters_.generation().incident_eta<<","<<
+      parameters_.generation().incident_phi<<")"<<std::endl; 
     std::cout << "incident energy: " <<parameters_.generation().energy<<" GeV"<<std::endl; 
     std::cout << "requested layer: " <<parameters_.geometry().layer<<std::endl; 
     std::cout<< "hexagon side: " <<parameters_.geometry().cell_side<< std::endl;
@@ -138,9 +137,9 @@ void Generator::simulate() {
     Event event(0, iev); // default run number =0
 
     event.setGenerated(parameters_.generation().energy, 
-        parameters_.generation().incident_x, 
-        parameters_.generation().incident_y,
-        parameters_.generation().incident_eta);
+        parameters_.generation().incident_eta,
+        parameters_.generation().incident_phi
+        );
 
     energygen = 0.;
     energygenincells = 0.;
@@ -182,23 +181,17 @@ void Generator::simulate() {
     }
 
     // incident position
-    double xinccor = parameters_.generation().incident_x;
-    //double xinccor = xinc - asqrt3over2 + asqrt3*gun->Rndm();
-    if (debug) std::cout << "shooting position = ("<< xinccor <<","<<parameters_.generation().incident_y<<")"<<std::endl;
+    // FIXME: use absolute z position  in config
+    double z = geometry_.getZlayer() + z0;
+    double incident_x = z*direction(0)/direction(2);
+    double incident_y = z*direction(1)/direction(2);
 
     for (int i=0; i<nhits; i++) {
 
-      double r = gun_.Exp(r0); // exponential exp(-r/r0)
-      double phi = gun_.Rndm()*TMath::TwoPi();
-      double x = r*cos(phi) + xinccor;
-      double y = r*sin(phi) + parameters_.generation().incident_y;
-
-      // add here translation for the requested layer
-      double z = geometry_.getZlayer();
-      if (z!=0.) {
-        x = x + z*direction(0)/direction(2);
-        y = y + z*direction(1)/direction(2);
-      }
+      double r_shower = gun_.Exp(r0); // exponential exp(-r/r0)
+      double phi_shower = gun_.Rndm()*TMath::TwoPi();
+      double x = r_shower*cos(phi_shower) + incident_x;
+      double y = r_shower*sin(phi_shower) + incident_y;
 
       TVectorD pos(2);
       pos(0)=x;
@@ -242,8 +235,8 @@ void Generator::simulate() {
       }	
 
      // fill shower histograms
-      hTransverseProfile.Fill(r,denrj);
-      hPhiProfile.Fill(phi,denrj);
+      hTransverseProfile.Fill(r_shower,denrj);
+      hPhiProfile.Fill(phi_shower,denrj);
       hSpotEnergy.Fill(denrj);
 
     }
@@ -318,15 +311,9 @@ void Generator::simulate() {
 
 
 std::unique_ptr<TCanvas> Generator::display(const std::unordered_map<uint32_t,TH1F>& hCellEnergyEvtMap, int ievt) {
-  double xdisplayoffset=0.;
-  double ydisplayoffset=0.;
-  if (parameters_.geometry().type==Parameters::Geometry::Type::External) {
-    xdisplayoffset=parameters_.display().offset_x;
-    ydisplayoffset=parameters_.display().offset_y;
-  }
 
   // FIXME: build titles without using char[]
-  std::string title1, title2, title3, title4;
+  std::string title1, title2, title4;
   char str[20];
   if (ievt == 0) title1 = "Mean energy profile in layer ";
   else title1 = "Event " + std::to_string(ievt) + " energy profile in layer ";
@@ -336,15 +323,6 @@ std::unique_ptr<TCanvas> Generator::display(const std::unordered_map<uint32_t,TH
   std::string string=str;
   title2 = title2 + string;
   title2 = title2 + " GeV", 
-         title3 = "position = (";
-  sprintf(str,"%3.1f",parameters_.generation().incident_x);
-  string=str;
-  title3 = title3 + string;
-  title3 = title3 + ",";
-  sprintf(str,"%3.1f",parameters_.generation().incident_y);
-  string=str;  
-  title3 = title3 + string;
-  title3 = title3 + ") cm";
   title4 = "eta = ";
   sprintf(str,"%3.1f",parameters_.generation().incident_eta);
   string=str;   
@@ -352,60 +330,48 @@ std::unique_ptr<TCanvas> Generator::display(const std::unordered_map<uint32_t,TH
   std::string title = title1 + ", ";
   title = title + title2;
   title = title + ", ";
-  title = title + title3;
-  title = title + ", ";
   title = title + title4;
 
   std::unique_ptr<TCanvas> c1(new TCanvas(title.c_str(),title.c_str(),700,700));
-  double scale=1./(parameters_.display().size*geometry_.asqrt3());
-  if (parameters_.geometry().type==Parameters::Geometry::Type::Triangles) scale=1./(parameters_.display().size*geometry_.aover2());
-  if (parameters_.geometry().type==Parameters::Geometry::Type::External) scale=1./(parameters_.display().size*0.22727*sqrt(3.)); // FIXME: hard coded a size for json geometry, to be improved
-  //double textsize=0.02;
-  geometry_.draw(parameters_.display());
-
+  TH2Poly* energy_map = (TH2Poly*)geometry_.cellHistogram()->Clone(std::string("test"+std::to_string(ievt)).c_str());
+  //geometry_.draw(parameters_.display());
 
   for (const auto& id_hist : hCellEnergyEvtMap) {
     const auto& cell = geometry_.getCells().at(id_hist.first);
     // print mean energies
     double enrj = id_hist.second.GetMean();
-    if (enrj<0.1) continue;
+    energy_map->Fill(cell.getPosition()(0), cell.getPosition()(1), enrj);
     // FIXME: no sprintf
     sprintf(str,"%4.1f",id_hist.second.GetMean());
-    //if (enrj<0.01) continue;
-    //int ires = sprintf(str,"%5.2f",(ic->second)->GetMean());
     // Calling Draw makes the current pad take the ownership of the object
     // So raw pointers are used, and the objects are deleted when the pad is deleted (here c1)
-    TText* t = new TText(cell.getPosition()(0)*scale+xdisplayoffset,
-        cell.getPosition()(1)*scale+ydisplayoffset,
-        str);
-    t->SetTextAlign(22);
-    t->SetTextColor(kBlack);
-    if (enrj>=1.) t->SetTextColor(kRed);
-    t->SetTextFont(43);
-    t->SetTextSize(20*11/parameters_.display().size);
-    //t->SetTextSize(0.02);
-    t->Draw();
+    //TText* t = new TText(cell.getPosition()(0)*scale+xdisplayoffset,
+        //cell.getPosition()(1)*scale+ydisplayoffset,
+        //str);
+    //t->SetTextAlign(22);
+    //t->SetTextColor(kBlack);
+    //if (enrj>=1.) t->SetTextColor(kRed);
+    //t->SetTextFont(43);
+    //t->SetTextSize(20*11/parameters_.display().size);
+    ////t->SetTextSize(0.02);
+    //t->Draw();
   } 
-  TPaveText* leg1 = new TPaveText(.05,.91,.35,.97);
+
+  energy_map->Draw("colz");
+
+  TPaveText* leg1 = new TPaveText(.05,.91,.35,.97, "NDC");
   leg1->AddText(title1.c_str());
   leg1->SetFillColor(kWhite);
   leg1->SetTextSize(0.02);
   leg1->Draw();
-  TPaveText* leg2 = new TPaveText(.045,.85,.18,.88);
+  TPaveText* leg2 = new TPaveText(.045,.85,.18,.88, "NDC");
   leg2->AddText(title2.c_str());
   leg2->SetFillColor(kWhite);
   leg2->SetTextSize(0.02);
   leg2->SetTextColor(kBlue);
   leg2->SetBorderSize(0.0);
   leg2->Draw();
-  TPaveText* leg3 = new TPaveText(.06,.79,.25,.84);
-  leg3->AddText(title3.c_str());
-  leg3->SetFillColor(kWhite);
-  leg3->SetTextSize(0.02);
-  leg3->SetTextColor(kBlue);
-  leg3->SetBorderSize(0.0);
-  leg3->Draw();
-  TPaveText* leg4 = new TPaveText(.05,.76,.13,.79);
+  TPaveText* leg4 = new TPaveText(.045,.79,.25,.84, "NDC");
   leg4->AddText(title4.c_str());
   leg4->SetFillColor(kWhite);
   leg4->SetTextSize(0.02);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -55,10 +55,8 @@ void Geometry::constructFromJson(bool debug) {
   // first set klayer and zlayer according to user parameters
   setLayer(parameters_.layer);
   double zlayer;
-  if (klayer_ == -1) zlayer = 0.;  // entry face required
+  if (klayer_ == -1) zlayer = parameters_.layers_z[0];  // first layer
   else zlayer = parameters_.layers_z[klayer_]; // else offset from the layer z position
-  // to force being at the center for any requested layer
-  //zlayer = 0.; 
   setZlayer(zlayer);
 
   // json format from Marina 06/2016
@@ -271,17 +269,15 @@ void Geometry::constructFromParameters(bool debug) {
   cells_.clear();
 
   double zlayer;
-  if (klayer == -1) zlayer = 0.;  // entry face required
+  if (klayer == -1) zlayer =  parameters_.layers_z[0];  // entry face required
   else zlayer = parameters_.layers_z[klayer]; // else offset from the layer z position
-  // to force being at the center for any requested layer
-  //zlayer = 0.; 
   setZlayer(zlayer);
 
   // I index run along x axis is defined such that hexagons are adjacent by side along this axis
   // J index runs along the y' axis is rotated by 60deg wrt x axis  
 
   // compute x,y positions of the geometry window
-  double z = zlayer + 320.; // FIXME: remove hardcoded z0
+  double z = zlayer; 
   double theta_min = 2.*std::atan(std::exp(-parameters_.eta_max));
   double theta_max = 2.*std::atan(std::exp(-parameters_.eta_min));
   double r_min = z*tan(theta_min);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -288,17 +288,21 @@ void Geometry::constructFromParameters(bool debug) {
   double r_max = z*tan(theta_max);
   double phi_min = parameters_.phi_min;
   double phi_max = parameters_.phi_max;
-  std::array<double, 4> xs = {
+  std::array<double, 6> xs = {
     r_min*cos(parameters_.phi_min),
     r_min*cos(parameters_.phi_max),
     r_max*cos(parameters_.phi_max),
-    r_max*cos(parameters_.phi_min)
+    r_max*cos(parameters_.phi_min),
+    r_min*cos((parameters_.phi_min+parameters_.phi_max)/2.),
+    r_max*cos((parameters_.phi_min+parameters_.phi_max)/2.)
   };
-  std::array<double, 4> ys = {
+  std::array<double, 6> ys = {
     r_min*sin(parameters_.phi_min),
     r_min*sin(parameters_.phi_max),
     r_max*sin(parameters_.phi_max),
-    r_max*sin(parameters_.phi_min)
+    r_max*sin(parameters_.phi_min),
+    r_min*sin((parameters_.phi_min+parameters_.phi_max)/2.),
+    r_max*sin((parameters_.phi_min+parameters_.phi_max)/2.)
   };
 
 
@@ -306,12 +310,20 @@ void Geometry::constructFromParameters(bool debug) {
   // x0,y0 is the origine of the tesselation
   // Which means that the center of cell (i,j)=(0,0) 
   // will be at (x,y)=(x0,y0)
-  double dx1 = xs[1]-xs[0];
-  double dy1 = ys[1]-ys[0];
-  double dx2 = xs[2]-xs[0];
-  double dy2 = ys[2]-ys[0];
-  double dx3 = xs[3]-xs[0];
-  double dy3 = ys[3]-ys[0];
+  std::array<double, 5> dx = {
+    xs[1]-xs[0],
+    xs[2]-xs[0],
+    xs[3]-xs[0],
+    xs[4]-xs[0],
+    xs[5]-xs[0]
+  };
+  std::array<double, 5> dy = {
+    ys[1]-ys[0],
+    ys[2]-ys[0],
+    ys[3]-ys[0],
+    ys[4]-ys[0],
+    ys[5]-ys[0]
+  };
 
   // partial derivatives of x,y vs i,j
   double dxdi = 0.;
@@ -336,8 +348,22 @@ void Geometry::constructFromParameters(bool debug) {
       break;
   };
   // compute i,j window needed to cover the x,y window
-  std::array<double,4> js = {0., dy1/dydj, dy2/dydj, dy3/dydj};
-  std::array<double,4> is = {0., (dx1-js[1]*dxdj)/dxdi, (dx2-js[2]*dxdj)/dxdi, (dx3-js[3]*dxdj)/dxdi};
+  std::array<double,6> js = {
+    0.,
+    dy[0]/dydj,
+    dy[1]/dydj,
+    dy[2]/dydj,
+    dy[3]/dydj,
+    dy[4]/dydj
+  };
+  std::array<double,6> is = {
+    0.,
+    (dx[0]-js[1]*dxdj)/dxdi,
+    (dx[1]-js[2]*dxdj)/dxdi,
+    (dx[2]-js[3]*dxdj)/dxdi,
+    (dx[3]-js[4]*dxdj)/dxdi,
+    (dx[4]-js[5]*dxdj)/dxdi
+  };
   int imin = std::round(*(std::min_element(is.begin(), is.end())));
   int jmin = std::round(*(std::min_element(js.begin(), js.end())));
   int imax = std::round(*(std::max_element(is.begin(), is.end())));
@@ -348,8 +374,8 @@ void Geometry::constructFromParameters(bool debug) {
   double y_min = std::numeric_limits<double>::max();
   double y_max = std::numeric_limits<double>::lowest();
   // build cells inside the requested window
-  for (int i=imin; i<imax;i++) {
-    for (int j=jmin; j<jmax;j++) {
+  for (int i=imin; i<=imax;i++) {
+    for (int j=jmin; j<=jmax;j++) {
       double x = xs[0] + i*dxdi + j*dxdj;
       double y = ys[0] + j*dydj;
       // up and down triangle barycenters are not aligned

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -281,22 +281,22 @@ void Geometry::constructFromParameters(bool debug) {
   double r_max = z*tan(theta_max);
   double phi_min = parameters_.phi_min;
   double phi_max = parameters_.phi_max;
-  std::array<double, 6> xs = {
+  std::array<double, 6> xs = {{
     r_min*cos(parameters_.phi_min),
     r_min*cos(parameters_.phi_max),
     r_max*cos(parameters_.phi_max),
     r_max*cos(parameters_.phi_min),
     r_min*cos((parameters_.phi_min+parameters_.phi_max)/2.),
     r_max*cos((parameters_.phi_min+parameters_.phi_max)/2.)
-  };
-  std::array<double, 6> ys = {
+  }};
+  std::array<double, 6> ys = {{
     r_min*sin(parameters_.phi_min),
     r_min*sin(parameters_.phi_max),
     r_max*sin(parameters_.phi_max),
     r_max*sin(parameters_.phi_min),
     r_min*sin((parameters_.phi_min+parameters_.phi_max)/2.),
     r_max*sin((parameters_.phi_min+parameters_.phi_max)/2.)
-  };
+  }};
 
 
   // x0,y0 is the origine of the tesselation

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 
 #include "TPolyLine.h"
+#include "TVector2.h"
+
 
 #ifdef STANDALONE
 #include "Geometry.h"
@@ -235,33 +237,25 @@ void Geometry::constructFromJson(bool debug) {
 void Geometry::constructFromParameters(bool debug) {
   // a tesselation of the plane with polygons
   double a(parameters_.cell_side);
-  int nrows(parameters_.cells_nx);
-  int ncols(parameters_.cells_ny);
   int klayer(parameters_.layer);
   Parameters::Geometry::Type itype(parameters_.type);
 
   if(debug) {
     std::cout << " " << std::endl;
-    std::cout << "Building parametrized geometry : " << nrows << " " << ncols  << std::endl;
-    // itype=0: heaxgonal cells
-    // itype=1: triangular cells
-    if (itype==Parameters::Geometry::Type::Hexagons) std:: cout << "with hexagonal cells " << std::endl;
-    else if (itype==Parameters::Geometry::Type::Triangles) std:: cout << "with triangular cells " << std::endl;
-
-    // itype=0: heaxgonal cells
-    // itype=1: triangular cells
+    std::cout << "Building parametrized geometry :\n";
+    std::cout << "  " << parameters_.eta_min << " < eta < " << parameters_.eta_max << "\n";
+    std::cout << "  " << parameters_.phi_min << " < phi < " << parameters_.phi_max << "\n";
     if (itype==Parameters::Geometry::Type::Hexagons) std:: cout << "with hexagonal cells " << std::endl;
     else if (itype==Parameters::Geometry::Type::Triangles) std:: cout << "with triangular cells " << std::endl;
   }
   
-  setNrows(nrows);
-  setNcols(ncols);
   setLayer(klayer);
   setType(itype);
   a_ = a;
   asqrt3_ = a*std::sqrt(3.);
   asqrt3over2_ = asqrt3_/2.;
   aover2_ = a/2.;
+  a3over2_ = aover2_*3.;
 
   // vertices coordinates wrt cell center
   const int nverticeshexagon=6; // hexagons
@@ -275,7 +269,6 @@ void Geometry::constructFromParameters(bool debug) {
   int nvertices=nverticeshexagon;
   if (itype==Parameters::Geometry::Type::Triangles) nvertices=nverticestriangle;
   cells_.clear();
-  //cells_.reserve(nrows*ncols);
 
   double zlayer;
   if (klayer == -1) zlayer = 0.;  // entry face required
@@ -287,39 +280,100 @@ void Geometry::constructFromParameters(bool debug) {
   // I index run along x axis is defined such that hexagons are adjacent by side along this axis
   // J index runs along the y' axis is rotated by 60deg wrt x axis  
 
-  // define an offset along the x-axis to fully fill the display pad with cells
-  double xoffset = parameters_.offset*asqrt3_;
-  if (itype==Parameters::Geometry::Type::Triangles) xoffset = parameters_.offset*aover2_;
+  // compute x,y positions of the geometry window
+  double z = zlayer + 320.; // FIXME: remove hardcoded z0
+  double theta_min = 2.*std::atan(std::exp(-parameters_.eta_max));
+  double theta_max = 2.*std::atan(std::exp(-parameters_.eta_min));
+  double r_min = z*tan(theta_min);
+  double r_max = z*tan(theta_max);
+  double phi_min = parameters_.phi_min;
+  double phi_max = parameters_.phi_max;
+  std::array<double, 4> xs = {
+    r_min*cos(parameters_.phi_min),
+    r_min*cos(parameters_.phi_max),
+    r_max*cos(parameters_.phi_max),
+    r_max*cos(parameters_.phi_min)
+  };
+  std::array<double, 4> ys = {
+    r_min*sin(parameters_.phi_min),
+    r_min*sin(parameters_.phi_max),
+    r_max*sin(parameters_.phi_max),
+    r_max*sin(parameters_.phi_min)
+  };
 
- for (int i=0; i<nrows_;i++) {
-    for (int j=0; j<ncols_;j++) {
+
+
+  // x0,y0 is the origine of the tesselation
+  // Which means that the center of cell (i,j)=(0,0) 
+  // will be at (x,y)=(x0,y0)
+  double dx1 = xs[1]-xs[0];
+  double dy1 = ys[1]-ys[0];
+  double dx2 = xs[2]-xs[0];
+  double dy2 = ys[2]-ys[0];
+  double dx3 = xs[3]-xs[0];
+  double dy3 = ys[3]-ys[0];
+
+  // partial derivatives of x,y vs i,j
+  double dxdi = 0.;
+  double dxdj = 0.;
+  double dydj = 0.;
+  switch(itype) {
+    case Parameters::Geometry::Type::Hexagons:
+      {
+        dxdi = asqrt3_;
+        dxdj = asqrt3over2_;
+        dydj = a3over2_;
+        break;
+      }
+    case Parameters::Geometry::Type::Triangles:
+      {
+        dxdi = aover2_;
+        dxdj = aover2_;
+        dydj = asqrt3over2_;
+        break;
+      }
+    default:
+      break;
+  };
+  // compute i,j window needed to cover the x,y window
+  std::array<double,4> js = {0., dy1/dydj, dy2/dydj, dy3/dydj};
+  std::array<double,4> is = {0., (dx1-js[1]*dxdj)/dxdi, (dx2-js[2]*dxdj)/dxdi, (dx3-js[3]*dxdj)/dxdi};
+  int imin = std::round(*(std::min_element(is.begin(), is.end())));
+  int jmin = std::round(*(std::min_element(js.begin(), js.end())));
+  int imax = std::round(*(std::max_element(is.begin(), is.end())));
+  int jmax = std::round(*(std::max_element(js.begin(), js.end())));
+
+  double x_min = std::numeric_limits<double>::max();
+  double x_max = std::numeric_limits<double>::lowest();
+  double y_min = std::numeric_limits<double>::max();
+  double y_max = std::numeric_limits<double>::lowest();
+  // build cells inside the requested window
+  for (int i=imin; i<imax;i++) {
+    for (int j=jmin; j<jmax;j++) {
+      double x = xs[0] + i*dxdi + j*dxdj;
+      double y = ys[0] + j*dydj;
+      // up and down triangle barycenters are not aligned
+      if(itype==Parameters::Geometry::Type::Triangles && i%2) y += asqrt3_/6.;
+      double r = std::sqrt(x*x + y*y);
+      double phi = std::acos(x/r);
+      // check if cell is inside boundaries. If not, skip it
+      if(!(r>=r_min && r<=r_max &&
+           TVector2::Phi_mpi_pi(phi-phi_min)>=0 && TVector2::Phi_mpi_pi(phi-phi_max)<=0
+          ))
+      {
+        continue;
+      }
+      if(x>x_max) x_max = x;
+      if(x<x_min) x_min = x;
+      if(y>y_max) y_max = y;
+      if(y<y_min) y_min = y;
+
       if (debug) {
         std::cout << "Creating new cell of type " << static_cast<std::underlying_type<Parameters::Geometry::Type>::type>(itype) << " : " << std::endl;
         std::cout << " mapping coordinates : " << 
           i << " " <<
           j << std::endl;
       }
-      double x=0., y=0.;
-      switch(itype) {
-        case Parameters::Geometry::Type::Hexagons:
-        {
-          x = xoffset + i*asqrt3_ + j*asqrt3over2_;
-          double yprime = j*asqrt3_;
-          // get back to the orthogonal y axis
-          y = yprime*asqrt3over2_/a_;
-          break;
-        }
-        case Parameters::Geometry::Type::Triangles:
-        {
-          x = xoffset + i*aover2_ + j*aover2_;
-          y = j*asqrt3over2_;
-          if (i%2 == 1) y = y + asqrt3_/6.; // cell center is shifted in y for downward triangles
-          break;
-        }
-        default:
-          break;
-      };
-
       TVectorD position(2);
       position(0) = x;
       position(1) = y;
@@ -366,27 +420,48 @@ void Geometry::constructFromParameters(bool debug) {
             break;
         };
         if (debug) {
-          std::cout << "  vertex " << i << " " << 
+          std::cout << "  vertex " << iv << " " << 
             vertices.back()(0) << " " <<
             vertices.back()(1) << std::endl;
         }
       }
 
-      cells_.emplace(
+      auto found = cells_.emplace(
           Cell::id(i, j),
           Cell(std::move(position),std::move(vertices),orientation,i,j)
           );
+      if(!found.second)
+      {
+        std::cout<<"Warning: Cell with indices"<<i<<" "<<j<<" already exists (id="<<Cell::id(i,j)<<")\n";
+        std::cout<<"Warning: This may indicate a bug in the id definition\n";
+      }
 
     }
+  }
+  // build histogram of cells
+  cell_histogram_ = new TH2Poly("cells", "cells",
+      x_min>0?x_min*0.9:x_min*1.1, x_max>0?x_max*1.1:x_max*0.9,
+      y_min>0?y_min*0.9:y_min*1.1, y_max>0?y_max*1.1:y_max*0.9
+      );
+  for (const auto& id_cell : cells_) { 
+    const auto& cell = id_cell.second;
+    std::vector<double> binsx, binsy;
+    for (const auto& vertex : cell.getVertices()) {
+      binsx.emplace_back(vertex(0));
+      binsy.emplace_back(vertex(1));
+    }
+    binsx.emplace_back(cell.getVertices()[0](0));
+    binsy.emplace_back(cell.getVertices()[0](1));
+    cell_histogram_->AddBin(binsx.size(), binsx.data(), binsy.data());
   }
 }
 
 void Geometry::setLayer(int klayer) {
 
   if (klayer<-1 || klayer>=28) {
-    std::cout << "[Geometry::Geometry] error, invalid klayer " << klayer << std::endl;
-    std::cout << "[Geometry::Geometry] setting klayer to entry face" << std::endl;
-    klayer_ = 0;
+    std::stringstream error;
+    error << "[Geometry] error, invalid klayer " << klayer;
+    throw error.str();
   } else if (klayer==-1) klayer_ = 0;
   else klayer_ = klayer;
 
@@ -408,63 +483,34 @@ void Geometry::print() {
 
 }
 
-void Geometry::draw(const Parameters::Display& params, double scale) {
+void Geometry::draw(const Parameters::Display& params) {
 
-  std::array<double, 7> summitx, summity;
+  cell_histogram_->Draw();
 
-  // for the case of the full geometry from json, offset the display by (0.5,0.5) such that
-  // the center of the module is at the center of the pad
-  double xdisplayoffset=0.;
-  double ydisplayoffset=0.;
-  if (itype_==Parameters::Geometry::Type::External) {
-    xdisplayoffset=params.offset_x;
-    ydisplayoffset=params.offset_y;
-  }
-
-  for (const auto& id_cell : cells_) { 
-    const auto& cell = id_cell.second;
-    unsigned i=0;
-    for (const auto& vertex : cell.getVertices()) {
-      summitx[i]=vertex(0)*scale+xdisplayoffset;
-      summity[i]=vertex(1)*scale+ydisplayoffset;
-      i++;
-    }
-    unsigned nvertices = cell.getVertices().size();
-    summitx[nvertices]=cell.getVertices()[0](0)*scale+xdisplayoffset;
-    summity[nvertices]=cell.getVertices()[0](1)*scale+ydisplayoffset;
-    // Calling Draw makes the current pad take the ownership of the object
-    // So raw pointers are used, and the objects are deleted when the pad is deleted
-    TPolyLine* polygon = new TPolyLine(nvertices+1,summitx.data(),summity.data());
-    polygon->SetFillColor(38);
-    polygon->SetLineColor(4);
-    polygon->SetLineWidth(1);
-    polygon->Draw();
-  } 
+  //std::array<double, 7> summitx, summity;
+  //for (const auto& id_cell : cells_) { 
+    //const auto& cell = id_cell.second;
+    //unsigned i=0;
+    //for (const auto& vertex : cell.getVertices()) {
+      //summitx[i]=vertex(0);
+      //summity[i]=vertex(1);
+      //i++;
+    //}
+    //unsigned nvertices = cell.getVertices().size();
+    //summitx[nvertices] = cell.getVertices()[0](0);
+    //summity[nvertices] = cell.getVertices()[0](1);
+    //// Calling Draw makes the current pad take the ownership of the object
+    //// So raw pointers are used, and the objects are deleted when the pad is deleted
+    //TPolyLine* polygon = new TPolyLine(nvertices+1,summitx.data(),summity.data());
+    //polygon->SetFillColor(38);
+    //polygon->SetLineColor(4);
+    //polygon->SetLineWidth(1);
+    ////polygon->Draw();
+  //} 
 
 }
 
 const TVectorD& Geometry::getPosition(int i, int j) const {
-
-  //TVectorD position(2);
-  //// for parameterised geometries uses indices
-  //// this is error prone (code duplication), do we really gain time?
-  //if (getType()!=Parameters::Geometry::Type::External) { 
-    //if (getType()==Parameters::Geometry::Type::Hexagons) { // hexagons
-      //position(0) = parameters_.offset*asqrt3_+i*asqrt3_+j*asqrt3over2_;
-      //double yprime = j*asqrt3_;
-      //position(1) = yprime*asqrt3over2_/a_;
-    //} else { // triangles
-      //position(0) = parameters_.offset*asqrt3_+i*aover2_+j*aover2_;
-      //position(1) = j*asqrt3over2_;    
-      //if (i%2 == 1) position(1) = position(1) + asqrt3_/6.; // cell center is shifted in y for downward triangles
-    //}
-  //} else { // full geometry
-  //for (const auto& id_cell : cells_) { 
-    //if (cell.getIIndex()!=i) continue; 
-    //if (cell.getJIndex()!=j) continue; 
-    //return cell.getPosition();
-  //}  
-  //throw std::string("Didn't find cell");
   // This will throw an exception if the cell is not found
   return cells_.at(Cell::id(i,j)).getPosition();
 }
@@ -531,15 +577,4 @@ bool Geometry::isInCell(const TVectorD& position, const Cell& cell) const {
   return true;
 }
 
-//int Geometry::getIIndex(const Cell& cell) const {
-
-  //return cell.getIIndex();
-
-//}
-
-//int Geometry::getJIndex(const Cell& cell) const {
-
-  //return cell.getJIndex();
-
-//}
 

--- a/src/OutputService.cpp
+++ b/src/OutputService.cpp
@@ -17,9 +17,8 @@ OutputService(const std::string& file_name):
   tree_->Branch("run", &run_, "run/i");
   tree_->Branch("event", &event_, "event/i");
   tree_->Branch("gen_energy", &gen_energy_, "gen_energy/F");
-  tree_->Branch("gen_x", &gen_x_, "gen_x/F");
-  tree_->Branch("gen_y", &gen_y_, "gen_y/F");
   tree_->Branch("gen_eta", &gen_eta_, "gen_eta/F");
+  tree_->Branch("gen_phi", &gen_phi_, "gen_phi/F");
   tree_->Branch("cell_n", &cell_n_, "cell_n/i");
   tree_->Branch("cell_energy", &cell_energy_);
   tree_->Branch("cell_x", &cell_x_);
@@ -42,9 +41,8 @@ fillTree(const Event& event, const Geometry& geometry)
   run_ = event.run();
   event_ = event.event();
   gen_energy_ = event.generatedEnergy();
-  gen_x_ = event.generatedX();
-  gen_y_ = event.generatedY();
   gen_eta_ = event.generatedEta();
+  gen_phi_ = event.generatedPhi();
   cell_n_ = event.hits().size();
   for(const auto& id_hit : event.hits())
   {
@@ -64,9 +62,8 @@ clear()
   run_ = 0;
   event_ = 0;
   gen_energy_ = 0.;
-  gen_x_ = 0.;
-  gen_y_ = 0.;
   gen_eta_ = 0.;
+  gen_phi_ = 0.;
   cell_n_ = 0;
   cell_energy_.clear();
   cell_x_.clear();

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -59,9 +59,8 @@ Generation():
   sampling(0.),
   noise(false),
   noise_sigma(0.),
-  incident_x(0.),
-  incident_y(0.),
-  incident_eta(0.)
+  incident_eta(0.),
+  incident_phi(0.)
 {
 }
 
@@ -160,9 +159,8 @@ fillGeneration(const python::dict& dict)
   generation_.sampling = python::extract<double>(dict["generation_sampling"]);
   generation_.noise = python::extract<bool>(dict["generation_noise"]);
   generation_.noise_sigma = python::extract<double>(dict["generation_noise_sigma"]);
-  generation_.incident_x = python::extract<double>(dict["generation_incident_x"]);
-  generation_.incident_y = python::extract<double>(dict["generation_incident_y"]);
   generation_.incident_eta = python::extract<double>(dict["generation_incident_eta"]);
+  generation_.incident_phi = python::extract<double>(dict["generation_incident_phi"]);
 }
 
 void 
@@ -229,8 +227,7 @@ print() const
   std::cout<<"|-- Sampling = "<<generation_.sampling<<"\n";
   std::cout<<"|-- Noise = "<<generation_.noise<<"\n";
   std::cout<<"|-- Noise sigma = "<<generation_.noise_sigma<<"\n";
-  std::cout<<"|-- Position = ("<<generation_.incident_x<<" "<<generation_.incident_y<<")\n";
-  std::cout<<"|-- Angle (eta) = "<<generation_.incident_eta<<"\n";
+  std::cout<<"|-- Direction = ("<<generation_.incident_eta<<" "<<generation_.incident_phi<<")\n";
   std::cout<<"|- Display\n";
   std::cout<<"|-- Events = "<<display_.events<<"\n";
   std::cout<<"|-- Size = "<<display_.size<<"\n";

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -66,10 +66,7 @@ Generation():
 
 Parameters::Display::
 Display():
-  events(0),
-  size(0),
-  offset_x(0.),
-  offset_y(0.)
+  events(0)
 {
 }
 
@@ -168,9 +165,6 @@ Parameters::
 fillDisplay(const python::dict& dict)
 {
   display_.events = python::extract<int>(dict["display_events"]);
-  display_.size = python::extract<int>(dict["display_size"]);
-  display_.offset_x = python::extract<double>(dict["display_offset_x"]);
-  display_.offset_y = python::extract<double>(dict["display_offset_y"]);
 }
 
 
@@ -230,6 +224,4 @@ print() const
   std::cout<<"|-- Direction = ("<<generation_.incident_eta<<" "<<generation_.incident_phi<<")\n";
   std::cout<<"|- Display\n";
   std::cout<<"|-- Events = "<<display_.events<<"\n";
-  std::cout<<"|-- Size = "<<display_.size<<"\n";
-  std::cout<<"|-- Offset = "<<display_.offset_x<<" "<<display_.offset_y<<"\n";
 }

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -30,9 +30,10 @@ Geometry():
   layer(-1),
   layers_z(0),
   cell_side(0),
-  offset(0),
-  cells_nx(0),
-  cells_ny(0),
+  eta_min(0.),
+  eta_max(0.),
+  phi_min(0.),
+  phi_max(0.),
   file("")
 {
 }
@@ -119,9 +120,10 @@ fillGeometry(const python::dict& dict)
   if(geometry_.type!=Geometry::Type::External)
   {
     geometry_.cell_side = python::extract<double>(dict["geometry_cell_side"]);
-    geometry_.offset = python::extract<int>(dict["geometry_offset"]);
-    geometry_.cells_nx = python::extract<int>(dict["geometry_cells_nx"]);
-    geometry_.cells_ny = python::extract<int>(dict["geometry_cells_ny"]);
+    geometry_.eta_min = python::extract<double>(dict["geometry_eta_min"]);
+    geometry_.eta_max = python::extract<double>(dict["geometry_eta_max"]);
+    geometry_.phi_min = python::extract<double>(dict["geometry_phi_min"]);
+    geometry_.phi_max = python::extract<double>(dict["geometry_phi_max"]);
   }
   // Read parameters for external json geometries
   else
@@ -187,9 +189,7 @@ print() const
   std::cout<<"|- Geometry\n";
   std::cout<<"|-- Type = "<<static_cast<std::underlying_type<Geometry::Type>::type>(geometry_.type)<<"\n";
   std::cout<<"|-- SideLength = "<<geometry_.cell_side<<"\n";
-  std::cout<<"|-- Cells_NX = "<<geometry_.cells_nx<<"\n";
-  std::cout<<"|-- Cells_NY = "<<geometry_.cells_ny<<"\n";
-  std::cout<<"|-- Offset = "<<geometry_.offset<<"\n";
+  std::cout<<"|-- eta|phi window = ("<<geometry_.eta_min<<","<<geometry_.eta_max<<"|"<<geometry_.phi_min<<","<<geometry_.phi_max<<")\n";
   std::cout<<"|-- Layer = "<<geometry_.layer<<"\n";
   std::cout<<"|-- Layers z = [";
   for(const auto& z : geometry_.layers_z)


### PR DESCRIPTION
- Use CMS-like coordinates, (0,0,0) being the centre of the detector
- Build parametrized geometry with an (eta,phi) window instead of an (i,j) window
- Generate shower at a given (eta,phi) direction instead of (x,y)
- Create output maps with histograms instead of sets of polygones
