### PR TITLE
Add predefined geometries

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,18 @@ The list of parameters in each group is as follows.
 | ------ | ------ | ------------ |  
 | `display_events` | `int` |  Number of events to display |  
 
-## Configuration utilities
+## Predefined configurations and utilities
 
-### Particle position
-The position of the generated position is given in (eta,phi), which requires some calculation if ones want to generate the particle at a particular position with respect to the cell grid.   
+### Predefined geometries
+Configuration files with predefined geometries are available:
+
+* `geometry_hexagon_large_cfg`, for hexagonal cells with the same size as large cells in CMSSW
+* `geometry_hexagon_small_cfg`, for hexagonal cells with the same size as small cells in CMSSW
+* `geometry_triangle_large_cfg`, for triangle cells with the same area as large cells in CMSSW
+* `geometry_triangle_small_cfg`, for triangle cells with the same area as small cells in CMSSW
+
+### Particle position utility
+The position of the generated particle is given in (eta,phi), which requires some calculation if ones wants to generate the particle at a particular position with respect to the cell grid.   
 Three functions are available to retrieve the (eta,phi) at the center, vertex or edge of a cell. They take an initial (eta,phi) as input and returns the (eta,phi) at the center of the closest cell, or at a given vertex or edge of the closest cell. They are defined in the file `python/generation_utils.py`. Currently they can only be used for the `Triangles` and `Hexagons` geometries, but not for external geometries.
 
 `shoot_cell_center` will return the (eta,phi) at the center of the closest cell.  

--- a/python/geometry_hexagon_large_cfg.py
+++ b/python/geometry_hexagon_large_cfg.py
@@ -1,0 +1,6 @@
+from geometry_cfg import *
+
+geometry_type = 'Hexagons'
+# cell side corresponding to the large 
+# hexagons in the CMSSW geometry 
+geometry_cell_side = 0.649 # cm

--- a/python/geometry_hexagon_small_cfg.py
+++ b/python/geometry_hexagon_small_cfg.py
@@ -1,0 +1,6 @@
+from geometry_cfg import *
+
+geometry_type = 'Hexagons'
+# cell side corresponding to the small
+# hexagons in the CMSSW geometry 
+geometry_cell_side = 0.476 # cm

--- a/python/geometry_triangle_large_cfg.py
+++ b/python/geometry_triangle_large_cfg.py
@@ -1,0 +1,6 @@
+from geometry_cfg import *
+
+geometry_type = 'Triangles'
+# cell side corresponding to the same area as large 
+# hexagons in the CMSSW geometry (hexagon side = 6.49mm)
+geometry_cell_side = 1.5897 # cm

--- a/python/geometry_triangle_small_cfg.py
+++ b/python/geometry_triangle_small_cfg.py
@@ -1,0 +1,6 @@
+from geometry_cfg import *
+
+geometry_type = 'Triangles'
+# cell side corresponding to the same area as small 
+# hexagons in the CMSSW geometry (hexagon side = 4.76mm)
+geometry_cell_side = 1.166 # cm

--- a/python/test_cfg.py
+++ b/python/test_cfg.py
@@ -19,7 +19,6 @@ events = 1
 debug = False
 output_file = 'test.root'
 
-geometry_type = 'Triangles'
 generation_incident_eta, generation_incident_phi = \
 shoot_cell_edge(eta=2.0, phi=0., edge_number=0,
                   # geometry window


### PR DESCRIPTION
Add predefined hexagon and triangle geometries with same areas as small and large cells in CMSSW